### PR TITLE
Documents our use of Peril and RFC process

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Code of Conduct
 
 We have our own [Code of Conduct](Code of Conduct.md), which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/). The CoC is taken seriously by the project owners.
 
-Automatic PR checking with Peril
+Automatic PR Checking with Peril
 --------------------------------
 
-[Peril](https://github.com/Danger/Peril) is a server which runs [Danger](http://danger.systems/js/) automatically, on all pull requests, organization-wide. We can check for pull request metadata, commit information, which files were changed, all kinds of thigs. Here is the list of checks which currently get run:
+[Peril](https://github.com/Danger/Peril) is a server which runs [Danger-JS](http://danger.systems/js/) automatically, on all pull requests, organization-wide. It can check for pull request metadata, commit information, which files were changed, all kinds of things. Here are the things Peril checks on _every_ RxSwiftCommunity repo's pull requests:
 
 - Ensuring that changes to non-test code are reflected in the changelog (if one exists). [PR](https://github.com/RxSwiftCommunity/peril/pull/1)
 

--- a/README.md
+++ b/README.md
@@ -41,4 +41,13 @@ Code of Conduct
 
 We have our own [Code of Conduct](Code of Conduct.md), which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/). The CoC is taken seriously by the project owners.
 
+Automatic PR checking with Peril
+--------------------------------
 
+[Peril](https://github.com/Danger/Peril) is a server which runs [Danger](http://danger.systems/js/) automatically, on all pull requests, organization-wide. We can check for pull request metadata, commit information, which files were changed, all kinds of thigs. Here is the list of checks which currently get run:
+
+- Ensuring that changes to non-test code are reflected in the changelog (if one exists). [PR](https://github.com/RxSwiftCommunity/peril/pull/1)
+
+If you have an idea for something we should check for in a pull request, or if you have an idea to improve the community using Peril to respond to issues, please [open an issue](https://github.com/RxSwiftCommunity/contributors/issues/new) so we can discuss!
+
+Our Peril settings are hosted [here](https://github.com/RxSwiftCommunity/peril). [@ashfurrow](https://github.com/ashfurrow) is the point person for Peril, ping him if you run into any issues.


### PR DESCRIPTION
This PR adds documentation about #28, including how to suggest new ways to use Peril.