### PR TITLE
Removes list of rules #trivial

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,4 @@ We have our own [Code of Conduct](Code of Conduct.md), which is adapted from the
 Automatic PR Checking with Peril
 --------------------------------
 
-[Peril](https://github.com/Danger/Peril) is a server which runs [Danger-JS](http://danger.systems/js/) automatically, on all pull requests, organization-wide. It can check for pull request metadata, commit information, which files were changed, all kinds of things. Here are the things Peril checks on _every_ RxSwiftCommunity repo's pull requests:
-
-- Ensuring that changes to non-test code are reflected in the changelog (if one exists). [PR](https://github.com/RxSwiftCommunity/peril/pull/1)
-
-If you have an idea for something we should check for in a pull request, or if you have an idea to improve the community using Peril to respond to issues, please [open an issue](https://github.com/RxSwiftCommunity/contributors/issues/new) so we can discuss!
-
-Our Peril settings are hosted [here](https://github.com/RxSwiftCommunity/peril). [@ashfurrow](https://github.com/ashfurrow) is the point person for Peril, ping him if you run into any issues.
+[Peril](https://github.com/Danger/Peril) is a server which runs [Danger-JS](http://danger.systems/js/) automatically, on all pull requests, organization-wide. The rules for our Peril server are [here](https://github.com/RxSwiftCommunity/peril), and we encourage everyone to think about new ways we could use Peril and Danger.


### PR DESCRIPTION
They were moved to the Peril repo in https://github.com/RxSwiftCommunity/peril/pull/7. Fixes https://github.com/RxSwiftCommunity/peril/issues/6. 